### PR TITLE
Fix Script Text Link

### DIFF
--- a/npc/re/instances/OldGlastHeim.txt
+++ b/npc/re/instances/OldGlastHeim.txt
@@ -2744,7 +2744,7 @@ glast_01,188,273,5	script	White Knight#1a	4_WHITEKNIGHT,{
 		close();
 	}
 	mes("I exchange you a White Knight Card for ^0000FF3000 Coagulated Spell^000000 or ^FF000070 Contaminated Magic^000000.");
-	mes("<ITEMLINK>White Knight Card<INFO>4608</INFO></ITEMLINK>");
+	mes("<ITEM>White Knight Card<INFO>4608</INFO></ITEM>");
 	next();
 	setarray(.@item[0], Coagulated_Spell, Corrupted_Charm);
 	setarray(.@cost[0], 3000, 70);
@@ -2777,7 +2777,7 @@ glast_01,192,273,3	script	Khalitzburg Knight#1a	4_F_KHALITZBURG,{
 		close();
 	}
 	mes("I exchange you a Khalitzburg Knight Card for ^0000FF5000 Coagulated Spell^000000 or ^FF0000100 Contaminated Magic^000000.");
-	mes("<ITEMLINK>Khalitzburg Knight Card<INFO>4609</INFO></ITEMLINK>");
+	mes("<ITEM>Khalitzburg Knight Card<INFO>4609</INFO></ITEM>");
 	next();
 	setarray(.@item[0], Coagulated_Spell, Corrupted_Charm);
 	setarray(.@cost[0], 5000, 100);


### PR DESCRIPTION
`<ITEMLINK>` was deprecated in 2015 and replaced with `<ITEM>`. Our client should be 2015+ so this should repair the link text.

May opt to do a run across all NPC scripts and make there are no other `<ITEMLINK>` references